### PR TITLE
Feat/lima 33263 Add possibility to disable creation of secret with Postgres credentials

### DIFF
--- a/charts/astroshop/Chart.yaml
+++ b/charts/astroshop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: astroshop
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.10
+version: 0.2.11
 # appVersion is used to establish the docker image tag
 # for each service, which means it should reflect the
 # latest desired build version

--- a/charts/astroshop/templates/postregresql-secret.yaml.tmpl
+++ b/charts/astroshop/templates/postregresql-secret.yaml.tmpl
@@ -1,7 +1,8 @@
+{{- if  index .Values "components" "postgres-credentials" "enabled" }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: postgres-secret
+  name: postgres-credentials
   namespace: "{{ .Release.Namespace }}"
   labels:
     app: postgres
@@ -12,3 +13,4 @@ stringData:
   postgres_password: "{{ .Values.default.postgresql_password }}"
   postgres_host: "{{ .Values.default.postgresql_host }}"
   postgres_port: "{{ .Values.default.postgresql_port }}"
+{{- end }}

--- a/charts/astroshop/templates/product-sql.yaml
+++ b/charts/astroshop/templates/product-sql.yaml
@@ -44,17 +44,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-credentials
                   key: postgres_user
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-credentials
                   key: postgres_password
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: postgres-secret
+                  name: postgres-credentials
                   key: postgres_db
 
           volumeMounts:

--- a/charts/astroshop/templates/product-sql.yaml.tmpl
+++ b/charts/astroshop/templates/product-sql.yaml.tmpl
@@ -1,3 +1,4 @@
+{{- if  index .Values "components" "product-db" "enabled" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -65,3 +66,4 @@ spec:
         - name: init-statement
           configMap:
             name: db-config
+{{- end }}

--- a/charts/astroshop/values.yaml
+++ b/charts/astroshop/values.yaml
@@ -23,6 +23,10 @@ components:
     ipWhitelist:
       base: []
       extra: []
+  postgres-credentials:
+    enabled: true
+    #when enabled secret with name `postgres-credentials` will be cerated automatically from values in `default` section.
+    #set do dsiabled if you want to provide  those values in other way
   product-db:
     enabled: true
     image: "postgres:15.1"
@@ -273,27 +277,27 @@ opentelemetry-demo:
         - name: POSTGRES_HOST
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: postgres-credentials
               key: postgres_host
         - name: POSTGRES_PORT
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: postgres-credentials
               key: postgres_port
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: postgres-credentials
               key: postgres_user        
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: postgres-credentials
               key: postgres_password
         - name: POSTGRES_DB
           valueFrom:
             secretKeyRef:
-              name: postgres-secret
+              name: postgres-credentials
               key: postgres_db
       resources:
         limits:


### PR DESCRIPTION
When using external Postgres database, we don't want to create Postgres database and secret with credentials. 
They can be disabled by `components/product-db/enabled` and `components/postgres-credentials/enabled`