### PR TITLE
chore: update image (928607a)

### DIFF
--- a/charts/astroshop/Chart.yaml
+++ b/charts/astroshop/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: astroshop
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "2.0.2"
 dependencies:
   - name: opentelemetry-demo

--- a/charts/astroshop/values.yaml
+++ b/charts/astroshop/values.yaml
@@ -44,7 +44,7 @@ opentelemetry-demo:
   default:
     image:
       repository: europe-docker.pkg.dev/dynatrace-demoability/docker/astroshop
-      tag: 7be95bf
+      tag: 928607a
   components:
     accounting:
       podAnnotations:


### PR DESCRIPTION
Update helm chart to use latest image (928607a) with added Live Debugger env variables to payment service.