### PR TITLE
chore: upgrade GitHub Actions to Node 24 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -31,7 +31,7 @@ jobs:
               pull_number: context.issue.number,
               event: "APPROVE"
             })
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |


### PR DESCRIPTION
## Summary

Upgrades outdated GitHub Actions to Node 24 compatible versions, fixing Node 20 deprecation warnings on GitHub-hosted runners.

**Related:** ASDY-27739

## Test plan

- [ ] CI passes on this PR
- [ ] No Node 20 deprecation warnings in workflow runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)